### PR TITLE
feature: Adding option to override accessibility props

### DIFF
--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -8,6 +8,7 @@ import {
   LayoutChangeEvent,
   I18nManager,
   Platform,
+  AccessibilityProps,
 } from 'react-native';
 import Animated from 'react-native-reanimated';
 import TabBarItem, { Props as TabBarItemProps } from './TabBarItem';
@@ -31,6 +32,7 @@ export type Props<T extends Route> = SceneRendererProps & {
   pressColor?: string;
   pressOpacity?: number;
   getLabelText: (scene: Scene<T>) => string | undefined;
+  tabAccessibilityProps?: AccessibilityProps;
   getAccessible: (scene: Scene<T>) => boolean | undefined;
   getAccessibilityLabel: (scene: Scene<T>) => string | undefined;
   getTestID: (scene: Scene<T>) => string | undefined;
@@ -326,6 +328,7 @@ export default class TabBar<T extends Route> extends React.Component<
       jumpTo,
       scrollEnabled,
       bounces,
+      tabAccessibilityProps,
       getAccessibilityLabel,
       getAccessible,
       getLabelText,
@@ -428,6 +431,7 @@ export default class TabBar<T extends Route> extends React.Component<
                 route: route,
                 navigationState: navigationState,
                 getAccessibilityLabel: getAccessibilityLabel,
+                tabAccessibilityProps: tabAccessibilityProps,
                 getAccessible: getAccessible,
                 getLabelText: getLabelText,
                 getTestID: getTestID,

--- a/src/TabBarItem.tsx
+++ b/src/TabBarItem.tsx
@@ -6,6 +6,7 @@ import {
   LayoutChangeEvent,
   TextStyle,
   ViewStyle,
+  AccessibilityProps,
 } from 'react-native';
 import TouchableItem from './TouchableItem';
 import { Scene, Route, NavigationState } from './types';
@@ -24,6 +25,7 @@ export type Props<T extends Route> = {
   pressColor?: string;
   pressOpacity?: number;
   getLabelText: (scene: Scene<T>) => string | undefined;
+  tabAccessibilityProps?: AccessibilityProps;
   getAccessible: (scene: Scene<T>) => boolean | undefined;
   getAccessibilityLabel: (scene: Scene<T>) => string | undefined;
   getTestID: (scene: Scene<T>) => string | undefined;
@@ -89,6 +91,7 @@ export default class TabBarItem<T extends Route> extends React.Component<
       renderBadge,
       getLabelText,
       getTestID,
+      tabAccessibilityProps,
       getAccessibilityLabel,
       getAccessible,
       activeColor = DEFAULT_ACTIVE_COLOR,
@@ -216,14 +219,6 @@ export default class TabBarItem<T extends Route> extends React.Component<
       <TouchableItem
         borderless
         testID={getTestID(scene)}
-        accessible={getAccessible(scene)}
-        accessibilityLabel={accessibilityLabel}
-        accessibilityTraits={isFocused ? ['button', 'selected'] : 'button'}
-        accessibilityComponentType="button"
-        accessibilityRole="tab"
-        accessibilityState={{ selected: isFocused }}
-        // @ts-ignore: this is to support older React Native versions
-        accessibilityStates={isFocused ? ['selected'] : []}
         pressColor={pressColor}
         pressOpacity={pressOpacity}
         delayPressIn={0}
@@ -231,6 +226,15 @@ export default class TabBarItem<T extends Route> extends React.Component<
         onPress={onPress}
         onLongPress={onLongPress}
         style={tabContainerStyle}
+        accessibilityTraits={isFocused ? ['button', 'selected'] : 'button'}
+        accessibilityComponentType="button"
+        accessibilityRole="tab"
+        accessibilityState={{ selected: isFocused }}
+        // @ts-ignore: this is to support older React Native versions
+        accessibilityStates={isFocused ? ['selected'] : []}
+        {...tabAccessibilityProps}
+        accessible={getAccessible(scene)}
+        accessibilityLabel={accessibilityLabel}
       >
         <View pointerEvents="none" style={[styles.item, tabStyle]}>
           {icon}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

With this pr, now any person using this library will be able to override some of the default props of accessibility. The idea is to solve the problem of the default role that the library has right now. For example in my case, I want to remove the role and the state and using it on a different way because it doesn't behaves as I want.

The idea is not override the `accessibilityLabel` or `accessible` props, because there is a way of handling them, so I just move them on a way to prevent this. No one won't be able to override `accessibilityLabel` or `accessible` but the user will be able to override any other prop related to accessibility

### Test plan

I think that just using the library in a normal way and sending some accessibility props to modify the configuration should be enough.

